### PR TITLE
Grant workflow permissions for code scanning

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main, dev, test/ci-cd-pipeline ]
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,6 +8,12 @@ on:
   schedule:
     - cron: '0 2 * * *' # Daily at 2 AM
 
+# Top-level permissions required for SARIF uploads and accessing workflow runs
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   # Dependency vulnerability scan
   dependency-scan:


### PR DESCRIPTION
Add top-level workflow permissions to resolve "Resource not accessible by integration" error for SARIF uploads.

The previous workflow runs failed with `Resource not accessible by integration` because the GitHub Action lacked the necessary permissions to access workflow run resources and upload SARIF files. Adding `actions: read`, `contents: read`, and `security-events: write` grants the required access.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b2cac20-b135-4612-8c4b-82cfef54163a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b2cac20-b135-4612-8c4b-82cfef54163a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

